### PR TITLE
fix(PinnedRepos): fix profile pictures not loading

### DIFF
--- a/src/components/organisms/Repos.svelte
+++ b/src/components/organisms/Repos.svelte
@@ -6,7 +6,18 @@
 
 	onMount(async () => {
 		const response = await fetch('https://gh-pinned-repos.egoist.dev/?username=xafn');
-		repos = await response.json();
+		let unpatched = await response.json()
+
+		// patch repo owners having a slash at the end of them
+		for (let i = 0; i < unpatched.length; i++) {
+			const element = unpatched[i];
+
+			if ((element.owner as string).endsWith("/")) {
+				unpatched[i].owner = unpatched[i].owner.slice(0, -1)
+			}
+		}
+
+		repos = unpatched
 	});
 </script>
 


### PR DESCRIPTION
hey, I'm back again with yet another fix

fixes `https://gh-pinned-repos.egoist.dev/` returning the owner's name with a slash at the end of it (for some reason) causing profile pictures to not loading properly. This only seems to happen with group GitHub accounts so this is just a temp patch until they fix it.

Pre patch:
![Prepatch](https://github.com/xafn/afn.im/assets/63677850/98385565-c520-454e-8e97-a33b375fd3a3)

Post patch:
![Postpatch](https://github.com/xafn/afn.im/assets/63677850/0efc3fd5-9a2b-41a6-aba8-77dd504ec2ed)

